### PR TITLE
Cache node modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   NODE_VERSION: 10
+  CI: true
 
 jobs:
   build:
@@ -33,8 +34,6 @@ jobs:
 
       - name: Test
         run: yarn test
-        env:
-          CI: true
 
       - name: Upload Artifact
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Get Yarn Cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Yarn
+      - name: Cache Node Modules
         uses: actions/cache@v1
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: node_modules
+          key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.OS }}-node-modules-
 
       - name: Install Dependencies
         run: yarn
@@ -62,17 +57,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Get Yarn Cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Yarn
+      - name: Cache Node Modules
         uses: actions/cache@v1
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: node_modules
+          key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
         run: yarn

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "postinstall": "cd functions && yarn"
+    "postinstall": "if [ -z \"$CI\" ]; then cd functions && yarn; fi"
   },
   "engines": {
     "node": "10"


### PR DESCRIPTION
## Changes
- Cache `node_modules` instead of Yarn cache
- Skip install node modules for `functions` directory in CI