### PR TITLE
Make playlists page as home

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import { AuthProvider } from 'auth';
 import { AppContextProvider } from 'context';
 import * as config from 'config';
 import { Layout } from 'components';
-import { Home, Playlist, Playlists, NeedSignIn, NotFound } from 'pages';
+import { Playlist, Playlists, NeedSignIn, NotFound } from 'pages';
 import theme from 'theme';
 
 export default function App() {
@@ -26,9 +26,6 @@ export default function App() {
               <Layout loading={isPending}>
                 <Switch>
                   <Route path="/" exact>
-                    <Home />
-                  </Route>
-                  <Route path="/playlist" exact>
                     {isAuthenticated ? <Playlists /> : <NeedSignIn />}
                   </Route>
                   <Route path="/playlist/:playlistId">

--- a/src/components/AsyncContainer.js
+++ b/src/components/AsyncContainer.js
@@ -36,6 +36,7 @@ export default withStyles((theme) => ({
     opacity: ({ loading }) => (loading ? 1 : 0),
     transition: `opacity ${transitionDuration}`,
   },
+  progress: {},
 }))(function AsyncContainer({
   classes,
   loading,
@@ -59,7 +60,10 @@ export default withStyles((theme) => ({
         classes={{ root: classes.progressContainer }}
         {...progressContainerProps}
       >
-        <CircularProgress {...progressProps} />
+        <CircularProgress
+          classes={{ root: classes.progress }}
+          {...progressProps}
+        />
       </Box>
     </Box>
   );

--- a/src/components/Layout/AppBar.js
+++ b/src/components/Layout/AppBar.js
@@ -5,35 +5,34 @@ import {
   Toolbar,
   Typography,
 } from '@material-ui/core';
-import MenuIcon from '@material-ui/icons/Menu';
 import { withStyles } from '@material-ui/core/styles';
-
-import { useAppContext } from 'context';
 
 import Auth from './Auth';
 
 export default withStyles((theme) => ({
-  menuButton: {
-    display: 'none',
+  primaryButton: {
     marginRight: theme.spacing(0.5),
   },
   title: {
     flexGrow: 1,
   },
-}))(function AppBar({ classes, children, onMenuButtonClick, ...props }) {
-  const [{ title }] = useAppContext();
-
+}))(function AppBar({
+  classes,
+  title,
+  primaryButtonProps,
+  children,
+  ...props
+}) {
   return (
     <MuiAppBar position="fixed" {...props}>
       <Toolbar>
         <IconButton
-          className={classes.menuButton}
+          classes={{ root: classes.primaryButton }}
           color="inherit"
           edge="start"
-          onClick={onMenuButtonClick}
-        >
-          <MenuIcon />
-        </IconButton>
+          {...primaryButtonProps}
+        />
+
         <Typography className={classes.title} variant="h6">
           {title}
         </Typography>

--- a/src/components/Layout/AppBar.js
+++ b/src/components/Layout/AppBar.js
@@ -14,6 +14,7 @@ import Auth from './Auth';
 
 export default withStyles((theme) => ({
   menuButton: {
+    display: 'none',
     marginRight: theme.spacing(0.5),
   },
   title: {

--- a/src/components/Layout/AppBar.js
+++ b/src/components/Layout/AppBar.js
@@ -15,6 +15,7 @@ export default withStyles((theme) => ({
   },
   title: {
     flexGrow: 1,
+    marginRight: theme.spacing(1),
   },
 }))(function AppBar({
   classes,
@@ -33,7 +34,7 @@ export default withStyles((theme) => ({
           {...primaryButtonProps}
         />
 
-        <Typography className={classes.title} variant="h6">
+        <Typography className={classes.title} variant="h6" noWrap>
           {title}
         </Typography>
 

--- a/src/components/Layout/Auth.js
+++ b/src/components/Layout/Auth.js
@@ -7,7 +7,6 @@ import {
   ListItem,
   ListItemAvatar,
   ListItemText,
-  Popover,
   SvgIcon,
 } from '@material-ui/core';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
@@ -15,6 +14,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { ReactComponent as GoogleIcon } from '@fortawesome/fontawesome-free/svgs/brands/google.svg';
 
 import { useAuth } from 'auth';
+import { usePopover } from 'hooks';
 
 const UserAvatar = withStyles((theme) => ({
   root: {
@@ -37,16 +37,7 @@ const UserButton = withStyles((theme) => ({
 }))(function UserButton({ classes, ...props }) {
   const { user, signOut } = useAuth();
 
-  const [detailsAnchorEl, setDetailsAnchorEl] = React.useState(null);
-  const isDetailsOpen = Boolean(detailsAnchorEl);
-
-  function onUserButtonClick(event) {
-    setDetailsAnchorEl(event.currentTarget);
-  }
-
-  function closeDetails() {
-    setDetailsAnchorEl(null);
-  }
+  const [Details, openDetails, closeDetails] = usePopover();
 
   function onSignOutButtonClick() {
     signOut();
@@ -58,15 +49,13 @@ const UserButton = withStyles((theme) => ({
       <IconButton
         className={classes.root}
         color="inherit"
-        onClick={onUserButtonClick}
+        onClick={openDetails}
         {...props}
       >
         <UserAvatar src={user.photoUrl} />
       </IconButton>
 
-      <Popover
-        open={isDetailsOpen}
-        anchorEl={detailsAnchorEl}
+      <Details
         keepMounted
         anchorOrigin={{
           vertical: 'bottom',
@@ -76,7 +65,6 @@ const UserButton = withStyles((theme) => ({
           vertical: 'top',
           horizontal: 'center',
         }}
-        onClose={closeDetails}
       >
         <List>
           <ListItem>
@@ -100,7 +88,7 @@ const UserButton = withStyles((theme) => ({
             />
           </ListItem>
         </List>
-      </Popover>
+      </Details>
     </>
   );
 });

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useTheme } from '@material-ui/core/styles';
 
 import { useAppContext } from 'context';
 import { AsyncContainer } from 'components';
@@ -25,6 +25,7 @@ export default withStyles((theme) => ({
     position: 'fixed',
   },
 }))(function Layout({ classes, children, ...props }) {
+  const theme = useTheme();
   const [{ appBarProps, isSidebarOpen }, updateContext] = useAppContext();
 
   const closeSideBar = React.useCallback(() => {
@@ -38,7 +39,7 @@ export default withStyles((theme) => ({
         contentContainer: classes.contentContainer,
         progressContainer: classes.progressContainer,
       }}
-      progressProps={{ size: '25vmin' }}
+      progressProps={{ size: theme.app.progressSize }}
       loadingContentOpacity={0}
       {...props}
     >

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import MenuIcon from '@material-ui/icons/Menu';
 import { withStyles } from '@material-ui/core/styles';
 
 import { useAppContext } from 'context';

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -8,8 +8,13 @@ import AppBar from './AppBar';
 import Sidebar from './Sidebar';
 
 export default withStyles((theme) => ({
+  '@global': {
+    'html, body, #root': {
+      height: '100%',
+    },
+  },
   root: {
-    minHeight: '100vh',
+    height: '100%',
   },
   contentContainer: {
     display: 'flex',

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import MenuIcon from '@material-ui/icons/Menu';
 import { withStyles } from '@material-ui/core/styles';
 
+import { useAppContext } from 'context';
 import { AsyncContainer } from 'components';
 
 import AppBar from './AppBar';
@@ -24,15 +26,11 @@ export default withStyles((theme) => ({
     position: 'fixed',
   },
 }))(function Layout({ classes, children, ...props }) {
-  const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
+  const [{ appBarProps, isSidebarOpen }, updateContext] = useAppContext();
 
-  function closeSideBar() {
-    setIsSidebarOpen(false);
-  }
-
-  function toggleSideBar() {
-    setIsSidebarOpen(!isSidebarOpen);
-  }
+  const closeSideBar = React.useCallback(() => {
+    updateContext({ isSidebarOpen: false });
+  }, [updateContext]);
 
   return (
     <AsyncContainer
@@ -45,7 +43,7 @@ export default withStyles((theme) => ({
       loadingContentOpacity={0}
       {...props}
     >
-      <AppBar onMenuButtonClick={toggleSideBar} />
+      <AppBar {...appBarProps} />
       <Sidebar open={isSidebarOpen} onClose={closeSideBar} />
       <div className={classes.appBarSpacer} />
       <main className={classes.main}>{children}</main>

--- a/src/components/Layout/Sidebar.js
+++ b/src/components/Layout/Sidebar.js
@@ -6,13 +6,19 @@ import {
   ListItemIcon,
   ListItemText,
 } from '@material-ui/core';
-import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
 import HomeIcon from '@material-ui/icons/Home';
 import { withStyles } from '@material-ui/core/styles';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 function MenuItem({ ...props }) {
-  return <ListItem component={Link} button {...props} />;
+  return (
+    <ListItem
+      component={NavLink}
+      button
+      activeClassName="Mui-selected"
+      {...props}
+    />
+  );
 }
 
 export default withStyles((theme) => ({
@@ -36,12 +42,6 @@ export default withStyles((theme) => ({
               <HomeIcon />
             </ListItemIcon>
             <ListItemText primary="Home" />
-          </MenuItem>
-          <MenuItem to="/playlist" onClick={onClose}>
-            <ListItemIcon>
-              <VideoLibraryIcon />
-            </ListItemIcon>
-            <ListItemText primary="Playlists" />
           </MenuItem>
         </List>
       </nav>

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -12,12 +12,14 @@ export default withStyles((theme) => ({
   progressContainer: {
     position: 'fixed',
   },
-}))(function Page({ classes, title = 'Cricket', ...props }) {
-  const [, updateContext] = useAppContext();
+}))(function Page({ classes, appBarProps, ...props }) {
+  const [, updateContext, defaultContext] = useAppContext();
 
   React.useEffect(() => {
-    updateContext({ title });
-  }, [title, updateContext]);
+    updateContext({
+      appBarProps: appBarProps ? appBarProps : defaultContext.appBarProps,
+    });
+  }, [appBarProps, updateContext, defaultContext.appBarProps]);
 
   return (
     <AsyncContainer

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useTheme } from '@material-ui/core/styles';
 
 import { useAppContext } from 'context';
 import { AsyncContainer } from 'components';
@@ -13,6 +13,7 @@ export default withStyles((theme) => ({
     position: 'fixed',
   },
 }))(function Page({ classes, appBarProps, ...props }) {
+  const theme = useTheme();
   const [, updateContext, defaultContext] = useAppContext();
 
   React.useEffect(() => {
@@ -24,7 +25,7 @@ export default withStyles((theme) => ({
   return (
     <AsyncContainer
       classes={classes}
-      progressProps={{ size: '25vmin' }}
+      progressProps={{ size: theme.app.progressSize }}
       {...props}
     />
   );

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { withStyles, useTheme } from '@material-ui/core/styles';
+import { Link } from 'react-router-dom';
 
 import { useAppContext } from 'context';
 import { AsyncContainer } from 'components';
@@ -12,15 +14,32 @@ export default withStyles((theme) => ({
   progressContainer: {
     position: 'fixed',
   },
-}))(function Page({ classes, appBarProps, ...props }) {
+}))(function Page({ classes, title, showHomeButton, appBarProps, ...props }) {
   const theme = useTheme();
   const [, updateContext, defaultContext] = useAppContext();
 
   React.useEffect(() => {
     updateContext({
-      appBarProps: appBarProps ? appBarProps : defaultContext.appBarProps,
+      appBarProps: {
+        ...defaultContext.appBarProps,
+        title: title || defaultContext.appBarProps.title,
+        ...(showHomeButton && {
+          primaryButtonProps: {
+            component: Link,
+            to: '/',
+            children: <ArrowBackIcon />,
+          },
+        }),
+        ...appBarProps,
+      },
     });
-  }, [appBarProps, updateContext, defaultContext.appBarProps]);
+  }, [
+    updateContext,
+    defaultContext.appBarProps,
+    title,
+    showHomeButton,
+    appBarProps,
+  ]);
 
   return (
     <AsyncContainer

--- a/src/context/AppContextProvider.js
+++ b/src/context/AppContextProvider.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import _ from 'lodash';
 import MenuIcon from '@material-ui/icons/Menu';
 
 import AppContext from './AppContext';

--- a/src/context/AppContextProvider.js
+++ b/src/context/AppContextProvider.js
@@ -4,7 +4,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import AppContext from './AppContext';
 
 export default function AppContextProvider({ children, ...props }) {
-  const [context, setContext] = React.useState({});
+  const [context, setContext] = React.useState();
 
   const updateContext = React.useCallback((newContext) => {
     setContext((prevContext) => ({
@@ -43,11 +43,12 @@ export default function AppContextProvider({ children, ...props }) {
       value={[context, updateContext, defaultContext]}
       {...props}
     >
-      {children instanceof Function ? (
-        <AppContext.Consumer>{children}</AppContext.Consumer>
-      ) : (
-        children
-      )}
+      {context &&
+        (children instanceof Function ? (
+          <AppContext.Consumer>{children}</AppContext.Consumer>
+        ) : (
+          children
+        ))}
     </AppContext.Provider>
   );
 }

--- a/src/context/AppContextProvider.js
+++ b/src/context/AppContextProvider.js
@@ -1,18 +1,49 @@
 import React from 'react';
+import _ from 'lodash';
+import MenuIcon from '@material-ui/icons/Menu';
 
 import AppContext from './AppContext';
 
 export default function AppContextProvider({ children, ...props }) {
-  const [context, setContext] = React.useState({
-    title: 'Cricket',
-  });
+  const [context, setContext] = React.useState({});
 
   const updateContext = React.useCallback((newContext) => {
-    setContext((prevContext) => ({ ...prevContext, ...newContext }));
+    setContext((prevContext) => ({
+      ...prevContext,
+      ...(newContext instanceof Function
+        ? newContext(prevContext)
+        : newContext),
+    }));
   }, []);
 
+  const defaultContext = React.useMemo(
+    () => ({
+      appBarProps: {
+        title: 'Cricket',
+        primaryButtonProps: {
+          style: { display: 'none' },
+          children: <MenuIcon />,
+          onClick: () => {
+            updateContext(({ isSidebarOpen }) => ({
+              isSidebarOpen: !isSidebarOpen,
+            }));
+          },
+        },
+      },
+      isSidebarOpen: false,
+    }),
+    [updateContext],
+  );
+
+  React.useEffect(() => {
+    setContext(defaultContext);
+  }, [defaultContext]);
+
   return (
-    <AppContext.Provider value={[context, updateContext]} {...props}>
+    <AppContext.Provider
+      value={[context, updateContext, defaultContext]}
+      {...props}
+    >
       {children instanceof Function ? (
         <AppContext.Consumer>{children}</AppContext.Consumer>
       ) : (

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useDialog } from './useDialog';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { default as useDialog } from './useDialog';
+export { default as usePopover } from './usePopover';

--- a/src/hooks/useDialog.js
+++ b/src/hooks/useDialog.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Dialog as MuiDialog } from '@material-ui/core';
+
+export default (component = MuiDialog) => {
+  const Component = component;
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const open = React.useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const close = React.useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const Dialog = React.useCallback(
+    function ControlledDialog({ ...props }) {
+      return <Component open={isOpen} onClose={close} {...props} />;
+    },
+    [isOpen, close],
+  );
+
+  return [Dialog, open, close];
+};

--- a/src/hooks/usePopover.js
+++ b/src/hooks/usePopover.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Popover as MuiPopover } from '@material-ui/core';
+
+export default (component = MuiPopover) => {
+  const Component = component;
+  const [anchorEl, setAnchorEl] = React.useState();
+
+  const open = React.useCallback((event) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const close = React.useCallback(() => {
+    setAnchorEl();
+  }, []);
+
+  const Popover = React.useCallback(
+    function ControlledPopover({ ...props }) {
+      return (
+        <Component
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={close}
+          {...props}
+        />
+      );
+    },
+    [anchorEl, close],
+  );
+
+  return [Popover, open, close];
+};

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
-
-import { Page } from 'components';
-
-export default withStyles((theme) => ({}))(function Home({ classes }) {
-  return <Page>Cricket</Page>;
-});

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -1,1 +1,0 @@
-export { default } from './Home';

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -15,7 +15,11 @@ export default withStyles((theme) => ({
   },
 }))(function NotFound({ classes }) {
   return (
-    <Page classes={{ contentContainer: classes.contentContainer }}>
+    <Page
+      classes={{ contentContainer: classes.contentContainer }}
+      title="Not Found"
+      showHomeButton
+    >
       <Typography variant="h3" gutterBottom>
         Sorry!
       </Typography>

--- a/src/pages/Playlist/AddItemDialog.js
+++ b/src/pages/Playlist/AddItemDialog.js
@@ -21,6 +21,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 import { youtube as youtubeApi } from 'api';
 import { AsyncContainer } from 'components';
+import { useDialog } from 'hooks';
 
 import itemMapper from './itemMapper';
 
@@ -51,7 +52,7 @@ async function searchYouTubeVideos(query) {
   return videos;
 }
 
-export default withStyles((theme) => ({
+const AddItemDialog = withStyles((theme) => ({
   searchField: {
     display: 'flex',
     alignItems: 'center',
@@ -206,3 +207,7 @@ export default withStyles((theme) => ({
     </Dialog>
   );
 });
+
+export const useAddItemDialog = () => useDialog(AddItemDialog);
+
+export default AddItemDialog;

--- a/src/pages/Playlist/DeleteItemDialog.js
+++ b/src/pages/Playlist/DeleteItemDialog.js
@@ -7,32 +7,28 @@ import { paths } from 'data';
 
 import { AsyncDialog } from 'components';
 
-export default withStyles((theme) => ({}))(function DeletePlaylistDialog({
+export default withStyles((theme) => ({}))(function DeleteItemDialog({
   classes,
-  playlist: { id, name },
+  playlistId,
+  item: { id, title },
   ...props
 }) {
   const handleOk = React.useCallback(async () => {
-    const functions = firebase.functions();
-
-    if (process.env.NODE_ENV === 'development') {
-      functions.useFunctionsEmulator('http://localhost:5000');
-    }
-
-    await functions.httpsCallable('recursiveDelete')({
-      path: `${paths.PLAYLISTS}/${id}`,
-    });
-  }, [id]);
+    await firebase
+      .firestore()
+      .doc(`${paths.PLAYLISTS}/${playlistId}/${paths.PLAYLIST_ITEMS}/${id}`)
+      .delete();
+  }, [playlistId, id]);
 
   return (
     <AsyncDialog
-      title="Delete Playlist"
+      title="Delete Item"
       okButtonProps={{ color: 'primary', children: 'Delete' }}
       onOk={handleOk}
       {...props}
     >
       <DialogContentText>
-        Are you sure to delete <strong>{name}</strong>?
+        Are you sure to delete <strong>{title}</strong>?
       </DialogContentText>
     </AsyncDialog>
   );

--- a/src/pages/Playlist/DeleteItemDialog.js
+++ b/src/pages/Playlist/DeleteItemDialog.js
@@ -4,10 +4,10 @@ import { withStyles } from '@material-ui/core/styles';
 import firebase from 'firebase/app';
 
 import { paths } from 'data';
-
 import { AsyncDialog } from 'components';
+import { useDialog } from 'hooks';
 
-export default withStyles((theme) => ({}))(function DeleteItemDialog({
+const DeleteItemDialog = withStyles((theme) => ({}))(function DeleteItemDialog({
   classes,
   playlistId,
   item: { id, title },
@@ -33,3 +33,7 @@ export default withStyles((theme) => ({}))(function DeleteItemDialog({
     </AsyncDialog>
   );
 });
+
+export const useDeleteItemDialog = () => useDialog(DeleteItemDialog);
+
+export default DeleteItemDialog;

--- a/src/pages/Playlist/MediaPlayer.js
+++ b/src/pages/Playlist/MediaPlayer.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import YouTube from 'react-youtube';
+
+export const PlayerState = {
+  UNSTARTED: 'unstarted',
+  ENDED: 'ended',
+  PLAYING: 'playing',
+  PAUSED: 'paused',
+  BUFFERING: 'buffering',
+  CUED: 'cued',
+};
+
+function mapYouTubePlayerState(youTubePlayerState) {
+  switch (youTubePlayerState) {
+    case YouTube.PlayerState.UNSTARTED:
+      return PlayerState.UNSTARTED;
+    case YouTube.PlayerState.ENDED:
+      return PlayerState.ENDED;
+    case YouTube.PlayerState.PLAYING:
+      return PlayerState.PLAYING;
+    case YouTube.PlayerState.PAUSED:
+      return PlayerState.PAUSED;
+    case YouTube.PlayerState.BUFFERING:
+      return PlayerState.BUFFERING;
+    case YouTube.PlayerState.CUED:
+      return PlayerState.CUED;
+    default:
+      return;
+  }
+}
+
+const youtubeOptions = {
+  width: '100%',
+  height: '100%',
+  allow: 'autoplay; fullscreen',
+  allowFullScreen: true,
+  playerVars: {
+    autoplay: 1,
+    playsinline: 1,
+    controls: 1,
+    modestbranding: 1,
+  },
+};
+
+export default withStyles((theme) => ({}))(function MediaPlayer({
+  classes,
+  type,
+  mediaId,
+  play,
+  onStateChange,
+  ...props
+}) {
+  const [player, setPlayer] = React.useState();
+
+  const handleReady = React.useCallback((event) => {
+    setPlayer(event.target);
+  }, []);
+
+  const handleStateChange = React.useCallback(
+    (event) => {
+      onStateChange(mapYouTubePlayerState(event.target.getPlayerState()));
+    },
+    [onStateChange],
+  );
+
+  React.useEffect(() => {
+    if (!player) {
+      return;
+    }
+
+    if (play) {
+      player.playVideo();
+    } else {
+      player.pauseVideo();
+    }
+  }, [player, play]);
+
+  return (
+    <YouTube
+      containerClassName={classes.youTube}
+      videoId={mediaId}
+      opts={youtubeOptions}
+      onReady={handleReady}
+      onStateChange={handleStateChange}
+      {...props}
+    />
+  );
+});

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -29,14 +29,26 @@ import MediaPlayer, { PlayerState } from './MediaPlayer';
 
 const scrollDuration = 300;
 
-const SortablePlaylistItem = SortableElement(({ item, ...props }) => (
-  <ScrollElement name={item.id}>
-    <PlaylistItem ContainerComponent="div" item={item} {...props} />
-  </ScrollElement>
-));
+const SortablePlaylistItem = SortableElement(function SortablePlaylistItem({
+  item,
+  ...props
+}) {
+  return (
+    <ScrollElement name={item.id}>
+      <PlaylistItem ContainerComponent="div" item={item} {...props} />
+    </ScrollElement>
+  );
+});
 
-const SortablePlaylist = SortableContainer(
-  ({ index, items, currentItem, selectItem, removeItem, ...props }) => (
+const SortablePlaylist = SortableContainer(function SortablePlaylist({
+  index,
+  items,
+  currentItem,
+  selectItem,
+  removeItem,
+  ...props
+}) {
+  return (
     <List dense {...props}>
       {_.map(items, (item, index) => (
         <SortablePlaylistItem
@@ -49,8 +61,8 @@ const SortablePlaylist = SortableContainer(
         />
       ))}
     </List>
-  ),
-);
+  );
+});
 
 export default withStyles((theme) => ({
   root: {

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -20,7 +20,7 @@ import {
 import { Page } from 'components';
 import { paths } from 'data';
 
-import AddItemDialog from './AddItemDialog';
+import { useAddItemDialog } from './AddItemDialog';
 import itemMapper from './itemMapper';
 import PlaylistItem from './PlaylistItem';
 import MediaPlayer, { PlayerState } from './MediaPlayer';
@@ -102,10 +102,15 @@ export default withStyles((theme) => ({
   const [playlist, setPlaylist] = React.useState();
   const [items, setItems] = React.useState();
   const [currentItem, setCurrentItem] = React.useState();
-  const [isAddItemDialogOpen, setIsAddItemDialogOpen] = React.useState(false);
   const [keepScrollToCurrentItem, setKeepScrollToCurrentItem] = React.useState(
     false,
   );
+
+  const [
+    AddItemDialog,
+    openAddItemDalog,
+    closeAddItemDialog,
+  ] = useAddItemDialog();
 
   const scrollToCurrentItem = React.useCallback(() => {
     if (!currentItem) {
@@ -123,14 +128,6 @@ export default withStyles((theme) => ({
     scroll.scrollToBottom({
       duration: scrollDuration,
     });
-  }, []);
-
-  const openAddItemDalog = React.useCallback(() => {
-    setIsAddItemDialogOpen(true);
-  }, []);
-
-  const closeAddItemDialog = React.useCallback(() => {
-    setIsAddItemDialogOpen(false);
   }, []);
 
   const addItem = React.useCallback(
@@ -373,11 +370,7 @@ export default withStyles((theme) => ({
         <AddIcon />
       </Fab>
 
-      <AddItemDialog
-        open={isAddItemDialogOpen}
-        onOk={addItem}
-        onClose={closeAddItemDialog}
-      />
+      <AddItemDialog onOk={addItem} />
     </Page>
   );
 });

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -40,10 +40,10 @@ const SortablePlaylistItem = SortableElement(function SortablePlaylistItem({
 
 const SortablePlaylist = SortableContainer(function SortablePlaylist({
   index,
+  playlistId,
   items,
   currentItem,
   selectItem,
-  removeItem,
   ...props
 }) {
   return (
@@ -52,10 +52,10 @@ const SortablePlaylist = SortableContainer(function SortablePlaylist({
         <SortablePlaylistItem
           key={item.id}
           index={index}
+          playlistId={playlistId}
           item={item}
           selected={currentItem && item.id === currentItem.id}
           onClick={selectItem(item)}
-          onRemoveButtonClick={removeItem(item)}
         />
       ))}
     </List>
@@ -157,25 +157,6 @@ export default withStyles((theme) => ({
       }
     },
     [playlistId, items, closeAddItemDialog, scrollToBottom],
-  );
-
-  const removeItem = React.useCallback(
-    ({ id }) => {
-      return async () => {
-        try {
-          setIsPending(true);
-          await firebase
-            .firestore()
-            .doc(
-              `${paths.PLAYLISTS}/${playlistId}/${paths.PLAYLIST_ITEMS}/${id}`,
-            )
-            .delete();
-        } finally {
-          setIsPending(false);
-        }
-      };
-    },
-    [playlistId],
   );
 
   const selectItem = React.useCallback((item) => {
@@ -339,10 +320,10 @@ export default withStyles((theme) => ({
         ) : (
           <SortablePlaylist
             className={classes.list}
+            playlistId={playlistId}
             items={items}
             currentItem={currentItem}
             selectItem={selectItem}
-            removeItem={removeItem}
             lockAxis="y"
             pressDelay={200}
             helperClass="sorting"

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -23,7 +23,7 @@ import { paths } from 'data';
 import { useAddItemDialog } from './AddItemDialog';
 import itemMapper from './itemMapper';
 import PlaylistItem from './PlaylistItem';
-import MediaPlayer, { PlayerState } from './MediaPlayer';
+import PlaylistToolbar, { PlayerState } from './PlaylistToolbar';
 
 const scrollDuration = 300;
 
@@ -80,22 +80,13 @@ export default withStyles((theme) => ({
   list: {
     marginBottom: '56vw',
   },
-  mediaPlayer: {
+  toolbar: {
     position: 'fixed',
     right: 0,
     bottom: 0,
     left: 0,
   },
-  mediaPlayerToolbar: {
-    paddingRight: theme.spacing(8),
-  },
-  mediaPlayerSpacer: theme.mixins.toolbar,
-  addItemButton: {
-    position: 'fixed',
-    right: theme.spacing(1),
-    bottom: theme.spacing(1),
-    zIndex: theme.zIndex.appBar,
-  },
+  playlistToolbarSpacer: theme.mixins.toolbar,
 }))(function Playlist({ classes }) {
   const { playlistId } = useParams();
   const [isPending, setIsPending] = React.useState();
@@ -329,13 +320,10 @@ export default withStyles((theme) => ({
           />
         ))}
 
-      <div className={classes.mediaPlayerSpacer} />
+      <div className={classes.playlistToolbarSpacer} />
 
-      <MediaPlayer
-        classes={{
-          root: classes.mediaPlayer,
-          toolbar: classes.mediaPlayerToolbar,
-        }}
+      <PlaylistToolbar
+        className={classes.toolbar}
         type={currentItem && currentItem.type}
         mediaId={currentItem && currentItem.mediaId}
         prevButtonProps={{
@@ -358,17 +346,11 @@ export default withStyles((theme) => ({
         scrollToBottomButtonProps={{
           onClick: scrollToBottom,
         }}
+        addItemButtonProps={{
+          onClick: openAddItemDalog,
+        }}
         onStateChange={handlePlayerStateChange}
       />
-
-      <Fab
-        classes={{ root: classes.addItemButton }}
-        size="small"
-        color="primary"
-        onClick={openAddItemDalog}
-      >
-        <AddIcon />
-      </Fab>
 
       <AddItemDialog onOk={addItem} />
     </Page>

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import fp from 'lodash/fp';
 import { Fab, List, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { withStyles } from '@material-ui/core/styles';
 import { useParams } from 'react-router-dom';
 import firebase from 'firebase/app';
@@ -16,6 +17,7 @@ import {
   SortableElement,
   arrayMove,
 } from 'react-sortable-hoc';
+import { Link } from 'react-router-dom';
 
 import { Page } from 'components';
 import { paths } from 'data';
@@ -309,7 +311,14 @@ export default withStyles((theme) => ({
   return (
     <Page
       className={classes.root}
-      title={playlist && playlist.name}
+      appBarProps={{
+        title: playlist ? playlist.name : 'Playlist',
+        primaryButtonProps: {
+          component: Link,
+          to: '/',
+          children: <ArrowBackIcon />,
+        },
+      }}
       loading={!playlist || !items || isPending}
     >
       {items &&

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -65,22 +65,22 @@ const SortablePlaylist = SortableContainer(function SortablePlaylist({
 });
 
 export default withStyles((theme) => ({
-  root: {
-    paddingBottom: 'calc(56vw + 60px)',
+  root: {},
+  contentContainer: {
+    display: 'flex',
+    flexFlow: 'column nowrap',
   },
   emptyMessageContainer: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-
+    flex: 1,
     display: 'flex',
     flexFlow: 'column nowrap',
     justifyContent: 'center',
 
     padding: theme.spacing(4),
     textAlign: 'center',
+  },
+  list: {
+    marginBottom: '56vw',
   },
   mediaPlayer: {
     position: 'fixed',
@@ -91,6 +91,7 @@ export default withStyles((theme) => ({
   mediaPlayerToolbar: {
     paddingRight: theme.spacing(8),
   },
+  mediaPlayerSpacer: theme.mixins.toolbar,
   addItemButton: {
     position: 'fixed',
     right: theme.spacing(1),
@@ -322,7 +323,10 @@ export default withStyles((theme) => ({
 
   return (
     <Page
-      className={classes.root}
+      classes={{
+        root: classes.root,
+        contentContainer: classes.contentContainer,
+      }}
       appBarProps={{
         title: playlist ? playlist.name : 'Playlist',
         primaryButtonProps: {
@@ -342,6 +346,7 @@ export default withStyles((theme) => ({
           </div>
         ) : (
           <SortablePlaylist
+            className={classes.list}
             items={items}
             currentItem={currentItem}
             selectItem={selectItem}
@@ -354,12 +359,13 @@ export default withStyles((theme) => ({
           />
         ))}
 
+      <div className={classes.mediaPlayerSpacer} />
+
       <MediaPlayer
         classes={{
           root: classes.mediaPlayer,
           toolbar: classes.mediaPlayerToolbar,
         }}
-        // style={{ display: currentItem ? 'block' : 'none' }}
         type={currentItem && currentItem.type}
         mediaId={currentItem && currentItem.mediaId}
         prevButtonProps={{

--- a/src/pages/Playlist/Playlist.js
+++ b/src/pages/Playlist/Playlist.js
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import fp from 'lodash/fp';
 import { Fab, List, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
-import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { withStyles } from '@material-ui/core/styles';
 import { useParams } from 'react-router-dom';
 import firebase from 'firebase/app';
@@ -17,7 +16,6 @@ import {
   SortableElement,
   arrayMove,
 } from 'react-sortable-hoc';
-import { Link } from 'react-router-dom';
 
 import { Page } from 'components';
 import { paths } from 'data';
@@ -327,14 +325,8 @@ export default withStyles((theme) => ({
         root: classes.root,
         contentContainer: classes.contentContainer,
       }}
-      appBarProps={{
-        title: playlist ? playlist.name : 'Playlist',
-        primaryButtonProps: {
-          component: Link,
-          to: '/',
-          children: <ArrowBackIcon />,
-        },
-      }}
+      title={playlist ? playlist.name : 'Playlist'}
+      showHomeButton
       loading={!playlist || !items || isPending}
     >
       {items &&

--- a/src/pages/Playlist/PlaylistItem.js
+++ b/src/pages/Playlist/PlaylistItem.js
@@ -10,23 +10,44 @@ import {
 import CloseIcon from '@material-ui/icons/Close';
 import { withStyles } from '@material-ui/core/styles';
 
+import DeleteItemDialog from './DeleteItemDialog';
+
 export default withStyles((theme) => ({}))(function PlaylistItem({
   classes,
+  playlistId,
   item,
-  onRemoveButtonClick,
   ...props
 }) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
+
+  const openDeleteDialog = React.useCallback(() => {
+    setIsDeleteDialogOpen(true);
+  }, []);
+
+  const closeDeleteDialog = React.useCallback(() => {
+    setIsDeleteDialogOpen(false);
+  }, []);
+
   return (
-    <ListItem alignItems="flex-start" button {...props}>
-      <ListItemAvatar>
-        <Avatar src={item.thumbnailUrl} variant="rounded" />
-      </ListItemAvatar>
-      <ListItemText primary={item.title} secondary={item.author} />
-      <ListItemSecondaryAction>
-        <IconButton edge="end" onClick={onRemoveButtonClick}>
-          <CloseIcon />
-        </IconButton>
-      </ListItemSecondaryAction>
-    </ListItem>
+    <>
+      <ListItem alignItems="flex-start" button {...props}>
+        <ListItemAvatar>
+          <Avatar src={item.thumbnailUrl} variant="rounded" />
+        </ListItemAvatar>
+        <ListItemText primary={item.title} secondary={item.author} />
+        <ListItemSecondaryAction>
+          <IconButton edge="end" onClick={openDeleteDialog}>
+            <CloseIcon />
+          </IconButton>
+        </ListItemSecondaryAction>
+      </ListItem>
+
+      <DeleteItemDialog
+        open={isDeleteDialogOpen}
+        playlistId={playlistId}
+        item={item}
+        onClose={closeDeleteDialog}
+      />
+    </>
   );
 });

--- a/src/pages/Playlist/PlaylistItem.js
+++ b/src/pages/Playlist/PlaylistItem.js
@@ -10,7 +10,7 @@ import {
 import CloseIcon from '@material-ui/icons/Close';
 import { withStyles } from '@material-ui/core/styles';
 
-import DeleteItemDialog from './DeleteItemDialog';
+import { useDeleteItemDialog } from './DeleteItemDialog';
 
 export default withStyles((theme) => ({}))(function PlaylistItem({
   classes,
@@ -18,15 +18,7 @@ export default withStyles((theme) => ({}))(function PlaylistItem({
   item,
   ...props
 }) {
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
-
-  const openDeleteDialog = React.useCallback(() => {
-    setIsDeleteDialogOpen(true);
-  }, []);
-
-  const closeDeleteDialog = React.useCallback(() => {
-    setIsDeleteDialogOpen(false);
-  }, []);
+  const [DeleteDialog, openDeleteDialog] = useDeleteItemDialog();
 
   return (
     <>
@@ -42,12 +34,7 @@ export default withStyles((theme) => ({}))(function PlaylistItem({
         </ListItemSecondaryAction>
       </ListItem>
 
-      <DeleteItemDialog
-        open={isDeleteDialogOpen}
-        playlistId={playlistId}
-        item={item}
-        onClose={closeDeleteDialog}
-      />
+      <DeleteDialog playlistId={playlistId} item={item} />
     </>
   );
 });

--- a/src/pages/Playlist/PlaylistToolbar.js
+++ b/src/pages/Playlist/PlaylistToolbar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Fab, IconButton, Paper, Toolbar } from '@material-ui/core';
+import { Fab, IconButton, Paper, Toolbar } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import SkipPreviousIcon from '@material-ui/icons/SkipPrevious';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
@@ -9,50 +9,10 @@ import VideoLabelIcon from '@material-ui/icons/VideoLabel';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
 import VerticalAlignBottomIcon from '@material-ui/icons/VerticalAlignBottom';
 import { withStyles } from '@material-ui/core/styles';
-import YouTube from 'react-youtube';
 
 import { AsyncContainer } from 'components';
 
-export const PlayerState = {
-  UNSTARTED: 'unstarted',
-  ENDED: 'ended',
-  PLAYING: 'playing',
-  PAUSED: 'paused',
-  BUFFERING: 'buffering',
-  CUED: 'cued',
-};
-
-function mapYouTubePlayerState(youTubePlayerState) {
-  switch (youTubePlayerState) {
-    case YouTube.PlayerState.UNSTARTED:
-      return PlayerState.UNSTARTED;
-    case YouTube.PlayerState.ENDED:
-      return PlayerState.ENDED;
-    case YouTube.PlayerState.PLAYING:
-      return PlayerState.PLAYING;
-    case YouTube.PlayerState.PAUSED:
-      return PlayerState.PAUSED;
-    case YouTube.PlayerState.BUFFERING:
-      return PlayerState.BUFFERING;
-    case YouTube.PlayerState.CUED:
-      return PlayerState.CUED;
-    default:
-      return;
-  }
-}
-
-const youtubeOptions = {
-  width: '100%',
-  height: '100%',
-  allow: 'autoplay; fullscreen',
-  allowFullScreen: true,
-  playerVars: {
-    autoplay: 1,
-    playsinline: 1,
-    controls: 1,
-    modestbranding: 1,
-  },
-};
+import { PlayerState } from './MediaPlayer';
 
 export default withStyles((theme) => ({
   root: {
@@ -60,23 +20,6 @@ export default withStyles((theme) => ({
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
     overflow: 'visible',
-  },
-  youTubeContainer: {
-    position: 'absolute',
-    top: '-56vw',
-    right: 0,
-    left: 0,
-
-    opacity: 0,
-    pointerEvents: 'none',
-    transition: 'opacity .3s',
-  },
-  youTubeContainerShow: {
-    opacity: 1,
-    pointerEvents: 'auto',
-  },
-  youTube: {
-    height: '56vw',
   },
   controls: {
     flex: 1,
@@ -86,8 +29,7 @@ export default withStyles((theme) => ({
   },
 }))(function PlaylistToolbar({
   classes,
-  type,
-  mediaId,
+  mediaPlayerState,
   toolbarProps,
   prevButtonProps,
   playPauseButtonProps,
@@ -96,50 +38,8 @@ export default withStyles((theme) => ({
   scrollToCurrentItemButtonProps,
   scrollToBottomButtonProps,
   addItemButtonProps,
-  onStateChange = () => {},
   ...props
 }) {
-  const [playerState, setPlayerState] = React.useState();
-  const [showVideo, setShowVideo] = React.useState(false);
-
-  const playerRef = React.useRef();
-
-  const handleReady = React.useCallback((event) => {
-    playerRef.current = event.target;
-  }, []);
-
-  const handleStateChange = React.useCallback(
-    (event) => {
-      const newState = mapYouTubePlayerState(event.target.getPlayerState());
-      setPlayerState(newState);
-      onStateChange(newState);
-    },
-    [onStateChange],
-  );
-
-  const togglePlay = React.useCallback(() => {
-    const player = playerRef.current;
-
-    if (player) {
-      switch (playerState) {
-        case PlayerState.PAUSED:
-          player.playVideo();
-          break;
-        case PlayerState.PLAYING:
-          player.pauseVideo();
-          break;
-        default:
-          break;
-      }
-    }
-
-    playPauseButtonProps.onClick();
-  }, [playerState, playPauseButtonProps]);
-
-  const toggleVideo = React.useCallback(() => {
-    setShowVideo(!showVideo);
-  }, [showVideo]);
-
   return (
     <Toolbar
       component={Paper}
@@ -147,19 +47,6 @@ export default withStyles((theme) => ({
       square
       {...props}
     >
-      <div
-        className={`${classes.youTubeContainer} ${showVideo &&
-          classes.youTubeContainerShow}`}
-      >
-        <YouTube
-          containerClassName={classes.youTube}
-          videoId={mediaId}
-          opts={youtubeOptions}
-          onReady={handleReady}
-          onStateChange={handleStateChange}
-        />
-      </div>
-
       <div className={classes.controls}>
         <IconButton {...prevButtonProps}>
           <SkipPreviousIcon />
@@ -167,11 +54,11 @@ export default withStyles((theme) => ({
 
         <AsyncContainer
           display="inline-flex"
-          loading={playerState === PlayerState.BUFFERING}
+          loading={mediaPlayerState === PlayerState.BUFFERING}
           loadingContentOpacity={0}
         >
-          <IconButton {...playPauseButtonProps} onClick={togglePlay}>
-            {playerState === PlayerState.PLAYING ? (
+          <IconButton {...playPauseButtonProps}>
+            {mediaPlayerState === PlayerState.PLAYING ? (
               <PauseIcon />
             ) : (
               <PlayArrowIcon />
@@ -183,11 +70,7 @@ export default withStyles((theme) => ({
           <SkipNextIcon />
         </IconButton>
 
-        <IconButton
-          color={showVideo ? 'primary' : 'default'}
-          {...toggleVideoButtonProps}
-          onClick={toggleVideo}
-        >
+        <IconButton {...toggleVideoButtonProps}>
           <VideoLabelIcon />
         </IconButton>
       </div>

--- a/src/pages/Playlist/PlaylistToolbar.js
+++ b/src/pages/Playlist/PlaylistToolbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Card, IconButton, Toolbar } from '@material-ui/core';
+import { Card, Fab, IconButton, Paper, Toolbar } from '@material-ui/core';
+import AddIcon from '@material-ui/icons/Add';
 import SkipPreviousIcon from '@material-ui/icons/SkipPrevious';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import PauseIcon from '@material-ui/icons/Pause';
@@ -55,12 +56,10 @@ const youtubeOptions = {
 
 export default withStyles((theme) => ({
   root: {
-    overflow: 'visible',
-  },
-  toolbar: {
     position: 'relative',
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
+    overflow: 'visible',
   },
   youTubeContainer: {
     position: 'absolute',
@@ -82,12 +81,13 @@ export default withStyles((theme) => ({
   controls: {
     flex: 1,
   },
-  secondaryControls: {},
-}))(function MediaPlayer({
+  secondaryControls: {
+    marginRight: theme.spacing(1),
+  },
+}))(function PlaylistToolbar({
   classes,
   type,
   mediaId,
-  fullscreen,
   toolbarProps,
   prevButtonProps,
   playPauseButtonProps,
@@ -95,6 +95,7 @@ export default withStyles((theme) => ({
   toggleVideoButtonProps,
   scrollToCurrentItemButtonProps,
   scrollToBottomButtonProps,
+  addItemButtonProps,
   onStateChange = () => {},
   ...props
 }) {
@@ -140,64 +141,70 @@ export default withStyles((theme) => ({
   }, [showVideo]);
 
   return (
-    <Card classes={{ root: classes.root }} square {...props}>
-      <Toolbar classes={{ root: classes.toolbar }} {...toolbarProps}>
-        <div
-          className={`${classes.youTubeContainer} ${showVideo &&
-            classes.youTubeContainerShow}`}
+    <Toolbar
+      component={Paper}
+      classes={{ root: classes.root }}
+      square
+      {...props}
+    >
+      <div
+        className={`${classes.youTubeContainer} ${showVideo &&
+          classes.youTubeContainerShow}`}
+      >
+        <YouTube
+          containerClassName={classes.youTube}
+          videoId={mediaId}
+          opts={youtubeOptions}
+          onReady={handleReady}
+          onStateChange={handleStateChange}
+        />
+      </div>
+
+      <div className={classes.controls}>
+        <IconButton {...prevButtonProps}>
+          <SkipPreviousIcon />
+        </IconButton>
+
+        <AsyncContainer
+          display="inline-flex"
+          loading={playerState === PlayerState.BUFFERING}
+          loadingContentOpacity={0}
         >
-          <YouTube
-            containerClassName={classes.youTube}
-            videoId={mediaId}
-            opts={youtubeOptions}
-            onReady={handleReady}
-            onStateChange={handleStateChange}
-          />
-        </div>
-
-        <div className={classes.controls}>
-          <IconButton {...prevButtonProps}>
-            <SkipPreviousIcon />
+          <IconButton {...playPauseButtonProps} onClick={togglePlay}>
+            {playerState === PlayerState.PLAYING ? (
+              <PauseIcon />
+            ) : (
+              <PlayArrowIcon />
+            )}
           </IconButton>
+        </AsyncContainer>
 
-          <AsyncContainer
-            display="inline-flex"
-            loading={playerState === PlayerState.BUFFERING}
-            loadingContentOpacity={0}
-          >
-            <IconButton {...playPauseButtonProps} onClick={togglePlay}>
-              {playerState === PlayerState.PLAYING ? (
-                <PauseIcon />
-              ) : (
-                <PlayArrowIcon />
-              )}
-            </IconButton>
-          </AsyncContainer>
+        <IconButton {...nextButtonProps}>
+          <SkipNextIcon />
+        </IconButton>
 
-          <IconButton {...nextButtonProps}>
-            <SkipNextIcon />
-          </IconButton>
+        <IconButton
+          color={showVideo ? 'primary' : 'default'}
+          {...toggleVideoButtonProps}
+          onClick={toggleVideo}
+        >
+          <VideoLabelIcon />
+        </IconButton>
+      </div>
 
-          <IconButton
-            size="small"
-            color={showVideo ? 'primary' : 'default'}
-            {...toggleVideoButtonProps}
-            onClick={toggleVideo}
-          >
-            <VideoLabelIcon />
-          </IconButton>
-        </div>
+      <div className={classes.secondaryControls}>
+        <IconButton size="small" {...scrollToCurrentItemButtonProps}>
+          <MyLocationIcon />
+        </IconButton>
 
-        <div className={classes.secondaryControls}>
-          <IconButton size="small" {...scrollToCurrentItemButtonProps}>
-            <MyLocationIcon />
-          </IconButton>
+        <IconButton size="small" {...scrollToBottomButtonProps}>
+          <VerticalAlignBottomIcon />
+        </IconButton>
+      </div>
 
-          <IconButton size="small" {...scrollToBottomButtonProps}>
-            <VerticalAlignBottomIcon />
-          </IconButton>
-        </div>
-      </Toolbar>
-    </Card>
+      <Fab size="small" color="primary" {...addItemButtonProps}>
+        <AddIcon />
+      </Fab>
+    </Toolbar>
   );
 });

--- a/src/pages/Playlists/AddPlaylistDialog.js
+++ b/src/pages/Playlists/AddPlaylistDialog.js
@@ -4,27 +4,32 @@ import firebase from 'firebase/app';
 
 import { useAuth } from 'auth';
 import { paths } from 'data';
+import { useDialog } from 'hooks';
 
 import PlaylistDialog from './PlaylistDialog';
 
-export default withStyles((theme) => ({}))(function AddPlaylistDialog({
-  ...props
-}) {
-  const { user } = useAuth();
+const AddPlaylistDialog = withStyles((theme) => ({}))(
+  function AddPlaylistDialog({ ...props }) {
+    const { user } = useAuth();
 
-  const handleOk = React.useCallback(
-    async ({ name }) => {
-      await firebase
-        .firestore()
-        .collection(paths.PLAYLISTS)
-        .add({
-          name,
-          ownerUserUids: [user.uid],
-          createdAt: new Date(),
-        });
-    },
-    [user.uid],
-  );
+    const handleOk = React.useCallback(
+      async ({ name }) => {
+        await firebase
+          .firestore()
+          .collection(paths.PLAYLISTS)
+          .add({
+            name,
+            ownerUserUids: [user.uid],
+            createdAt: new Date(),
+          });
+      },
+      [user.uid],
+    );
 
-  return <PlaylistDialog title="New Playlist" onOk={handleOk} {...props} />;
-});
+    return <PlaylistDialog title="New Playlist" onOk={handleOk} {...props} />;
+  },
+);
+
+export const useAddPlaylistDialog = () => useDialog(AddPlaylistDialog);
+
+export default AddPlaylistDialog;

--- a/src/pages/Playlists/DeletePlaylistDialog.js
+++ b/src/pages/Playlists/DeletePlaylistDialog.js
@@ -6,34 +6,37 @@ import firebase from 'firebase/app';
 import { paths } from 'data';
 
 import { AsyncDialog } from 'components';
+import { useDialog } from 'hooks';
 
-export default withStyles((theme) => ({}))(function DeletePlaylistDialog({
-  classes,
-  playlist: { id, name },
-  ...props
-}) {
-  const handleOk = React.useCallback(async () => {
-    const functions = firebase.functions();
+const DeletePlaylistDialog = withStyles((theme) => ({}))(
+  function DeletePlaylistDialog({ classes, playlist: { id, name }, ...props }) {
+    const handleOk = React.useCallback(async () => {
+      const functions = firebase.functions();
 
-    if (process.env.NODE_ENV === 'development') {
-      functions.useFunctionsEmulator('http://localhost:5000');
-    }
+      if (process.env.NODE_ENV === 'development') {
+        functions.useFunctionsEmulator('http://localhost:5000');
+      }
 
-    await functions.httpsCallable('recursiveDelete')({
-      path: `${paths.PLAYLISTS}/${id}`,
-    });
-  }, [id]);
+      await functions.httpsCallable('recursiveDelete')({
+        path: `${paths.PLAYLISTS}/${id}`,
+      });
+    }, [id]);
 
-  return (
-    <AsyncDialog
-      title="Delete Playlist"
-      okButtonProps={{ color: 'primary', children: 'Delete' }}
-      onOk={handleOk}
-      {...props}
-    >
-      <DialogContentText>
-        Are you sure to delete <strong>{name}</strong>?
-      </DialogContentText>
-    </AsyncDialog>
-  );
-});
+    return (
+      <AsyncDialog
+        title="Delete Playlist"
+        okButtonProps={{ color: 'primary', children: 'Delete' }}
+        onOk={handleOk}
+        {...props}
+      >
+        <DialogContentText>
+          Are you sure to delete <strong>{name}</strong>?
+        </DialogContentText>
+      </AsyncDialog>
+    );
+  },
+);
+
+export const useDeletePlaylistDialog = () => useDialog(DeletePlaylistDialog);
+
+export default DeletePlaylistDialog;

--- a/src/pages/Playlists/EditPlaylistDialog.js
+++ b/src/pages/Playlists/EditPlaylistDialog.js
@@ -3,21 +3,28 @@ import { withStyles } from '@material-ui/core/styles';
 import firebase from 'firebase/app';
 
 import { paths } from 'data';
+import { useDialog } from 'hooks';
 
 import PlaylistDialog from './PlaylistDialog';
 
-export default withStyles((theme) => ({}))(function EditPlaylistDialog({
-  ...props
-}) {
-  const handleOk = React.useCallback(async ({ id, name }) => {
-    await firebase
-      .firestore()
-      .collection(paths.PLAYLISTS)
-      .doc(id)
-      .update({
-        name,
-      });
-  }, []);
+const EditPlaylistDialog = withStyles((theme) => ({}))(
+  function EditPlaylistDialog({ ...props }) {
+    const handleOk = React.useCallback(async ({ id, name }) => {
+      await firebase
+        .firestore()
+        .collection(paths.PLAYLISTS)
+        .doc(id)
+        .update({
+          name,
+        });
+    }, []);
 
-  return <PlaylistDialog title="Rename Playlist" onOk={handleOk} {...props} />;
-});
+    return (
+      <PlaylistDialog title="Rename Playlist" onOk={handleOk} {...props} />
+    );
+  },
+);
+
+export const useEditPlaylistDialog = () => useDialog(EditPlaylistDialog);
+
+export default EditPlaylistDialog;

--- a/src/pages/Playlists/Playlist.js
+++ b/src/pages/Playlists/Playlist.js
@@ -11,6 +11,7 @@ import {
 import CloseIcon from '@material-ui/icons/Close';
 import EditIcon from '@material-ui/icons/Edit';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
+import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
 import { withStyles } from '@material-ui/core/styles';
 import { formatDistanceWithOptions } from 'date-fns/fp';
 import { Link } from 'react-router-dom';
@@ -70,6 +71,9 @@ export default withStyles((theme) => ({}))(function Playlists({
         to={`/playlist/${playlist.id}`}
         {...props}
       >
+        <ListItemIcon>
+          <VideoLibraryIcon />
+        </ListItemIcon>
         <ListItemText
           primary={playlist.name}
           secondary={formatDistanceWithOptions(

--- a/src/pages/Playlists/Playlist.js
+++ b/src/pages/Playlists/Playlist.js
@@ -15,8 +15,8 @@ import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 
-import EditPlaylistDialog from './EditPlaylistDialog';
-import DeletePlaylistDialog from './DeletePlaylistDialog';
+import { useEditPlaylistDialog } from './EditPlaylistDialog';
+import { useDeletePlaylistDialog } from './DeletePlaylistDialog';
 
 export default withStyles((theme) => ({}))(function Playlists({
   classes,
@@ -24,8 +24,11 @@ export default withStyles((theme) => ({}))(function Playlists({
   count = 0,
   ...props
 }) {
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
-  const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
+  const [
+    DeletePlaylistDialog,
+    openDeletePlaylistDialog,
+  ] = useDeletePlaylistDialog();
+  const [EditPlaylistDialog, openEditPlaylistDialog] = useEditPlaylistDialog();
 
   const [anchorEl, setAnchorEl] = React.useState();
 
@@ -37,31 +40,15 @@ export default withStyles((theme) => ({}))(function Playlists({
     setAnchorEl();
   }, []);
 
-  const openDeleteDialog = React.useCallback(() => {
-    setIsDeleteDialogOpen(true);
-  }, []);
-
-  const closeDeleteDialog = React.useCallback(() => {
-    setIsDeleteDialogOpen(false);
-  }, []);
-
   const handleDeleteButtonClick = React.useCallback(() => {
     closeMenu();
-    openDeleteDialog();
-  }, [closeMenu, openDeleteDialog]);
-
-  const openEditDialog = React.useCallback(() => {
-    setIsEditDialogOpen(true);
-  }, []);
-
-  const closeEditDialog = React.useCallback(() => {
-    setIsEditDialogOpen(false);
-  }, []);
+    openDeletePlaylistDialog();
+  }, [closeMenu, openDeletePlaylistDialog]);
 
   const handleEditButtonClick = React.useCallback(() => {
     closeMenu();
-    openEditDialog();
-  }, [closeMenu, openEditDialog]);
+    openEditPlaylistDialog();
+  }, [closeMenu, openEditPlaylistDialog]);
 
   return (
     <>
@@ -98,17 +85,9 @@ export default withStyles((theme) => ({}))(function Playlists({
         </MenuItem>
       </Menu>
 
-      <EditPlaylistDialog
-        open={isEditDialogOpen}
-        playlist={playlist}
-        onClose={closeEditDialog}
-      />
+      <EditPlaylistDialog playlist={playlist} />
 
-      <DeletePlaylistDialog
-        open={isDeleteDialogOpen}
-        playlist={playlist}
-        onClose={closeDeleteDialog}
-      />
+      <DeletePlaylistDialog playlist={playlist} />
     </>
   );
 });

--- a/src/pages/Playlists/Playlist.js
+++ b/src/pages/Playlists/Playlist.js
@@ -13,7 +13,6 @@ import EditIcon from '@material-ui/icons/Edit';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
 import { withStyles } from '@material-ui/core/styles';
-import { formatDistanceWithOptions } from 'date-fns/fp';
 import { Link } from 'react-router-dom';
 
 import EditPlaylistDialog from './EditPlaylistDialog';
@@ -22,6 +21,7 @@ import DeletePlaylistDialog from './DeletePlaylistDialog';
 export default withStyles((theme) => ({}))(function Playlists({
   classes,
   playlist,
+  count = 0,
   ...props
 }) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
@@ -74,13 +74,7 @@ export default withStyles((theme) => ({}))(function Playlists({
         <ListItemIcon>
           <VideoLibraryIcon />
         </ListItemIcon>
-        <ListItemText
-          primary={playlist.name}
-          secondary={formatDistanceWithOptions(
-            { addSuffix: true },
-            new Date(),
-          )(playlist.createdAt.toDate())}
-        />
+        <ListItemText primary={playlist.name} secondary={`${count} Items`} />
         <ListItemSecondaryAction>
           <IconButton edge="end" onClick={handleOpenMenuButtonClick}>
             <MoreVertIcon />

--- a/src/pages/Playlists/Playlist.js
+++ b/src/pages/Playlists/Playlist.js
@@ -15,6 +15,8 @@ import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 
+import { usePopover } from 'hooks';
+
 import { useEditPlaylistDialog } from './EditPlaylistDialog';
 import { useDeletePlaylistDialog } from './DeletePlaylistDialog';
 
@@ -29,26 +31,17 @@ export default withStyles((theme) => ({}))(function Playlists({
     openDeletePlaylistDialog,
   ] = useDeletePlaylistDialog();
   const [EditPlaylistDialog, openEditPlaylistDialog] = useEditPlaylistDialog();
-
-  const [anchorEl, setAnchorEl] = React.useState();
-
-  const handleOpenMenuButtonClick = React.useCallback((event) => {
-    setAnchorEl(event.currentTarget);
-  }, []);
-
-  const closeMenu = React.useCallback(() => {
-    setAnchorEl();
-  }, []);
+  const [PlaylistMenu, openPlaylistMenu, closePlaylistMenu] = usePopover(Menu);
 
   const handleDeleteButtonClick = React.useCallback(() => {
-    closeMenu();
+    closePlaylistMenu();
     openDeletePlaylistDialog();
-  }, [closeMenu, openDeletePlaylistDialog]);
+  }, [closePlaylistMenu, openDeletePlaylistDialog]);
 
   const handleEditButtonClick = React.useCallback(() => {
-    closeMenu();
+    closePlaylistMenu();
     openEditPlaylistDialog();
-  }, [closeMenu, openEditPlaylistDialog]);
+  }, [closePlaylistMenu, openEditPlaylistDialog]);
 
   return (
     <>
@@ -63,13 +56,13 @@ export default withStyles((theme) => ({}))(function Playlists({
         </ListItemIcon>
         <ListItemText primary={playlist.name} secondary={`${count} Items`} />
         <ListItemSecondaryAction>
-          <IconButton edge="end" onClick={handleOpenMenuButtonClick}>
+          <IconButton edge="end" onClick={openPlaylistMenu}>
             <MoreVertIcon />
           </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
 
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>
+      <PlaylistMenu>
         <MenuItem dense onClick={handleEditButtonClick}>
           <ListItemIcon>
             <EditIcon />
@@ -83,7 +76,7 @@ export default withStyles((theme) => ({}))(function Playlists({
           </ListItemIcon>
           <ListItemText>Delete</ListItemText>
         </MenuItem>
-      </Menu>
+      </PlaylistMenu>
 
       <EditPlaylistDialog playlist={playlist} />
 

--- a/src/pages/Playlists/Playlists.js
+++ b/src/pages/Playlists/Playlists.js
@@ -67,7 +67,7 @@ export default withStyles((theme) => ({
   }, [isPendingAuth, user]);
 
   return (
-    <Page className={classes.root} title="Playlists" loading={!playlists}>
+    <Page className={classes.root} loading={!playlists}>
       {playlists &&
         (_.isEmpty(playlists) ? (
           <div className={classes.emptyMessageContainer}>

--- a/src/pages/Playlists/Playlists.js
+++ b/src/pages/Playlists/Playlists.js
@@ -10,7 +10,7 @@ import { paths } from 'data';
 import { useAuth } from 'auth';
 import { Page } from 'components';
 
-import AddPlaylistDialog from './AddPlaylistDialog';
+import { useAddPlaylistDialog } from './AddPlaylistDialog';
 import Playlist from './Playlist';
 
 export default withStyles((theme) => ({
@@ -40,15 +40,8 @@ export default withStyles((theme) => ({
   const { isPending: isPendingAuth, user } = useAuth();
   const [playlists, setPlaylists] = React.useState();
   const [playlistItemCounts, setPlaylistItemCounts] = React.useState({});
-  const [isAddDialogOpen, setIsAddDialogOpen] = React.useState(false);
 
-  const openAddDialog = React.useCallback(() => {
-    setIsAddDialogOpen(true);
-  }, []);
-
-  const closeAddDialog = React.useCallback(() => {
-    setIsAddDialogOpen(false);
-  }, []);
+  const [AddPlaylistDialog, openAddPlaylistDialog] = useAddPlaylistDialog();
 
   React.useEffect(() => {
     if (isPendingAuth) {
@@ -113,12 +106,12 @@ export default withStyles((theme) => ({
       <Fab
         classes={{ root: classes.addButton }}
         color="primary"
-        onClick={openAddDialog}
+        onClick={openAddPlaylistDialog}
       >
         <AddIcon />
       </Fab>
 
-      <AddPlaylistDialog open={isAddDialogOpen} onClose={closeAddDialog} />
+      <AddPlaylistDialog />
     </Page>
   );
 });

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,3 @@
-export { default as Home } from './Home';
 export { default as NeedSignIn } from './NeedSignIn';
 export { default as NotFound } from './NotFound';
 export { default as Playlist } from './Playlist';

--- a/src/theme/app.js
+++ b/src/theme/app.js
@@ -1,3 +1,4 @@
 export default {
   sidebarWidth: 240,
+  progressSize: '25vmin',
 };


### PR DESCRIPTION
## Changes
- Make playlists page as home
- Change app bar buttons via context
- Show home button on app bar at playlist page & not found page
- Display # of playlist items at playlists page
- Fix unexpected scroll on mobile
- Ask before delete item
- Create `useDialog()` & `usePopover()`
- Extract `MediaPlayer` from toolbar